### PR TITLE
Change confusion matrix dtype

### DIFF
--- a/metric/confusionmatrix.py
+++ b/metric/confusionmatrix.py
@@ -74,7 +74,7 @@ class ConfusionMatrix(metric.Metric):
         # hack for bincounting 2 arrays together
         x = predicted + self.num_classes * target
         bincount_2d = np.bincount(
-            x.astype(np.int32), minlength=self.num_classes**2)
+            x.astype(np.int64), minlength=self.num_classes**2)
         assert bincount_2d.size == self.num_classes**2
         conf = bincount_2d.reshape((self.num_classes, self.num_classes))
 

--- a/metric/confusionmatrix.py
+++ b/metric/confusionmatrix.py
@@ -19,7 +19,7 @@ class ConfusionMatrix(metric.Metric):
     def __init__(self, num_classes, normalized=False):
         super().__init__()
 
-        self.conf = np.ndarray((num_classes, num_classes), dtype=np.int32)
+        self.conf = np.ndarray((num_classes, num_classes), dtype=np.int64)
         self.normalized = normalized
         self.num_classes = num_classes
         self.reset()


### PR DESCRIPTION
The accumulation of the confusion matrix produces overflows if you have a large data set.
Matrix is currently stored as int32.
If you have a dataset with 10^5 images and 10^5 pixels per image (480*360=172800) the maximum true positive number is 10^10 > 2^32 ~ 10^9.
Changed the dtype of the matrix to int64 to solve the problem.